### PR TITLE
fix example in readme, spawner -> scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ fn main(){
     let mut v = vec![0; 256];
 
     // Create a scoped spawner.
-    pool.scope(|spawner| {
+    pool.scope(|scope| {
         for chunk in v.chunks_mut(32) {
 
             // Jobs spawned by the scope are only allowed to access


### PR DESCRIPTION
That should be `scope` instead of `spawner` in the example.

I've also compared some other parallelisazion crates using a [mandelbrot](https://github.com/willi-kappler/mandel-rust) set.
