### PR TITLE
Fix borrow error in second example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ fn main(){
                 for i in chunk { *i += 1 }
             });
         }
-
-        for i in v {
-            assert_eq!(i, 1);
-        }
     });
     // all jobs within the scope are forced to complete before the scope function returns.
 
+    for i in v {
+        assert_eq!(i, 1);
+    }
 }
 ```
 


### PR DESCRIPTION
The second example tried to read from `v` while mutable references to chunks of `v` were still owned by the jobs in the scope, causing the example to fail to compile.

This commit moves the verification step outside of the scope so that the jobs end first and those references are no longer owned.